### PR TITLE
Translated two pages into Korean.

### DIFF
--- a/_posts/2009-01-09-checkout-remote-tracked-branch.textile
+++ b/_posts/2009-01-09-checkout-remote-tracked-branch.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: checkout tracked remote branch
 category: intermediate

--- a/_posts/2009-01-10-stashing-your-changes.textile
+++ b/_posts/2009-01-10-stashing-your-changes.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: stashing your changes
 category: beginner

--- a/_posts/2009-01-11-reverting-files.textile
+++ b/_posts/2009-01-11-reverting-files.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: reverting files
 category: beginner

--- a/_posts/2009-01-12-fixing-broken-commit-messages.textile
+++ b/_posts/2009-01-12-fixing-broken-commit-messages.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: fixing broken commit messages
 category: advanced

--- a/_posts/2009-01-12-fixing-broken-commit-messages.textile
+++ b/_posts/2009-01-12-fixing-broken-commit-messages.textile
@@ -1,29 +1,29 @@
 ---
-published: false
+published: true
 layout: post
-title: fixing broken commit messages
+title: 깨진 커밋 메시지 고치기
 category: advanced
 ---
 
-You just committed that awesome feature/test/bug, but something just isn't right. Either some information isn't filled out, the commit message is wrong, or something else is just messed up. Let's go over what can be done to fix the associated data after the fact.
+당신은 지금 막 대단한 feature/test/bug를 커밋했는데, 뭔가 잘못되었다. 어떤 정보가 빠졌거나, 커밋 메시지가 잘못되었거나, 아니면 또 다른 뭔가가 엉망이다. 사고를 친 후에 그와 관련된 데이터들을 고치려면 무엇을 해야 하는지 지금부터 알아보자.
 
-Fixing the previous commit is very simple. Just use
+이전 커밋을 고치는 것은 간단하다. 그냥 이렇게 하면 된다.
 
 @git commit --amend@
 
-And that will fire up the commit patch in $EDITOR for you to mess with. Simply edit the message right on the top line of the file, save, quit and you're done. 
+그러면 당신이 커밋 패치를 손볼 수 있도록 $EDITOR로 띄워 줄 것이다. 그냥 파일 가장 위의 메시지를 고치고, 저장하고, 종료하면 끝난다.
 
-Now let's say you've got a few commits to fix, or the commit that is broken is a few commits back. This process is a little more complex, but isn't too bad. (Thanks to "Evan Phoenix":http://blog.fallingsnow.net/ for this one.)
+이제 여러 커밋을 고쳐야 하거나, 옛날에 했던 커밋이 깨진 것을 발견한 경우에 대해 이야기해보자. 이 프로세스는 약간 복잡하지만, 그렇게 심하진 않다. ("Evan Phoenix":http://blog.fallingsnow.net/ 에게 감사의 말을 전한다)
 
-Here's the scenario: the last 3 commits don't have the right username, email, or perhaps commit message. Let's start by generating patch files for the commits:
+여기 시나리오가 있다: 지난 세번의 커밋은 username, email, 혹은 커밋 메시지가 잘못되어있다. 이 커밋들에 대한 패치를 만드는 것에서 시작해보자.
 
 @git format-patch HEAD^^^@
 
-That will generate files in the form of 0001-commit-message that contains the commit diff and metadata. One note with the 3 caret symbols: just add one for each commit you need to go back, and be consistent! *EDIT:* You can also refer to past commits with the syntax HEAD~n, so for this example we'd use HEAD~3. Go ahead and edit these files so they have the proper information. Once that's done, we'll need to reset our repository back a few commits:
+이렇게 하면 commit diff와 메타데이터들이 포함된 파일들이 0001-commit-message 와 같은 형식으로 생성된다. ^^^(3 caret symbols)에 대해: 되돌아가고 싶은 커밋 당 ^를 하나씩 추가하면 된다. *추가:* HEAD~n 식의 문법으로도 이전 커밋을 참조할 수 있으므로, 이 경우에 우린 HEAD~3을 사용해왔다. 계속해서 이 파일들이 알맞은 정보를 갖도록 고쳐라. 이게 끝나면, 우리는 저장소를 예전 커밋으로 되돌릴 것이다.
 
 @git reset --hard HEAD^^^@
 
-Now we can apply each commit to fix the information. Make sure you do it in the right order! (Usually it's ascending)
+이제 우린 정보를 고치기 위해 각 커밋을 적용할 수 있다. 커밋 순서에 주의하라! (보통 오름차순이다)
 
 <pre>
 git am < 0001...
@@ -31,14 +31,14 @@ git am < 0002...
 git am < 0003...
 </pre>
 
-Now if you check @git log@ you should see the right information. If for some reason stuff got messed up, doing a 
+이제 @git log@ 를 체크해보면 정보가 바르게 들어가 있는 것을 볼 수 있다. 만약 어떤 이유로 뭔가 꼬였을 땐 다음과 같이 하면,
 
 @git reset --hard origin/master@
 
-will bring you back to your original changes. Once you've got the information fixed, you'll need to do a force push on the repo:
+저장소를 원래대로 돌려놓을 것이다. 정보가 바르게 고쳐졌다면, 저장소에 강제로 push 할 필요가 있다.
 
 @git push -f@
 
-If you don't add the @-f@, git will complain. *WARNING!* Just be aware that modifying commit messages may muck up other's repositories and should be used with caution. In fact, other developers may flat out hate you for doing this. If it's far back enough it's probably a "bad idea to rewrite history anyway.":http://www.youtube.com/watch?v=BytKSy8M4bk
+만약 -f 를 빠뜨리면 git가 불평한다. *주의!* 커밋 메시지를 수정하는 것은 다른 사람들의 저장소를 망칠 수 있으므로 조심스럽게 사용해야 함을 명심하라. 사실 이런 짓을 하면, 다른 개발자들은 아마 당신을 맹렬히 싫어할 것이다. 예전 같았으면, 이건 아마 "역사를 무작정 고쳐쓰려는 나쁜 생각": http://www.youtube.com/watch?v=BytKSy8M4bk 이었을 것이다.
 
-If you know of any unexpected or uncovered consequences please let us know in the comments. Another tip in the future will cover fixing the actual committed files and making sure that all repos are up to date.
+여기서 빠뜨린 것이 있거나 예상치 못한 상황을 만났다면 댓글로 알려달라. 나중에 올릴 팁에서는 실제로 커밋된 파일을 고치고 모든 저장소에 반영하는 방법에 대해 다룰 것이다.

--- a/_posts/2009-01-13-visualizing-your-repo.textile
+++ b/_posts/2009-01-13-visualizing-your-repo.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: visualizing your repo
 category: intermediate

--- a/_posts/2009-01-14-interactive-adding.textile
+++ b/_posts/2009-01-14-interactive-adding.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: interactive adding
 category: intermediate

--- a/_posts/2009-01-15-piecemeal-staging.textile
+++ b/_posts/2009-01-15-piecemeal-staging.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: piecemeal staging
 category: advanced

--- a/_posts/2009-01-16-cleaning-up-untracked-files.textile
+++ b/_posts/2009-01-16-cleaning-up-untracked-files.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: cleaning up untracked files
 category: beginner

--- a/_posts/2009-01-17-restoring-lost-commits.textile
+++ b/_posts/2009-01-17-restoring-lost-commits.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: restoring lost commits
 category: advanced

--- a/_posts/2009-01-18-the-staging-area.textile
+++ b/_posts/2009-01-18-the-staging-area.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: the staging area
 category: beginner

--- a/_posts/2009-01-19-ignoring-files.textile
+++ b/_posts/2009-01-19-ignoring-files.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: ignoring files
 category: beginner

--- a/_posts/2009-01-20-bend-logs-to-your-will.textile
+++ b/_posts/2009-01-20-bend-logs-to-your-will.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: bend logs to your will
 category: advanced

--- a/_posts/2009-01-21-pushing-and-pulling.textile
+++ b/_posts/2009-01-21-pushing-and-pulling.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: pushing and pulling
 category: beginner

--- a/_posts/2009-01-22-count-your-commits.textile
+++ b/_posts/2009-01-22-count-your-commits.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: count your commits
 category: intermediate

--- a/_posts/2009-01-23-bash-git-status.textile
+++ b/_posts/2009-01-23-bash-git-status.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: bash git status
 category: advanced

--- a/_posts/2009-01-24-sharing-your-changes.textile
+++ b/_posts/2009-01-24-sharing-your-changes.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: sharing your changes
 category: intermediate

--- a/_posts/2009-01-25-branching-and-merging.textile
+++ b/_posts/2009-01-25-branching-and-merging.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: branching and merging
 category: beginner

--- a/_posts/2009-01-26-text-based-graph.textile
+++ b/_posts/2009-01-26-text-based-graph.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: text-based graph
 category: intermediate

--- a/_posts/2009-01-27-installing-git.textile
+++ b/_posts/2009-01-27-installing-git.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: installing git
 category: beginner

--- a/_posts/2009-01-28-zsh-git-status.textile
+++ b/_posts/2009-01-28-zsh-git-status.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: zsh git status
 category: advanced

--- a/_posts/2009-01-29-exporting-your-repository.textile
+++ b/_posts/2009-01-29-exporting-your-repository.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: exporting your repository
 category: intermediate

--- a/_posts/2009-01-30-finding-what-has-been-changed.textile
+++ b/_posts/2009-01-30-finding-what-has-been-changed.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: finding what has been changed
 category: intermediate

--- a/_posts/2009-01-31-intro-to-rebase.textile
+++ b/_posts/2009-01-31-intro-to-rebase.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: intro to rebase
 category: intermediate

--- a/_posts/2009-02-01-push-to-only-bare-repositories.textile
+++ b/_posts/2009-02-01-push-to-only-bare-repositories.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: push to only bare repositories
 category: advanced

--- a/_posts/2009-02-02-push-and-delete-branches.textile
+++ b/_posts/2009-02-02-push-and-delete-branches.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: push and delete remote branches
 category: beginner

--- a/_posts/2009-02-03-tagging.textile
+++ b/_posts/2009-02-03-tagging.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: tagging
 category: beginner

--- a/_posts/2009-02-04-converting-from-svn.textile
+++ b/_posts/2009-02-04-converting-from-svn.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: converting from svn
 category: beginner

--- a/_posts/2009-02-05-bash-auto-completion.textile
+++ b/_posts/2009-02-05-bash-auto-completion.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: bash auto completion
 category: advanced

--- a/_posts/2009-02-06-helpful-command-aliases.textile
+++ b/_posts/2009-02-06-helpful-command-aliases.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: helpful command aliases
 category: intermediate

--- a/_posts/2009-02-09-reflog-your-safety-net.textile
+++ b/_posts/2009-02-09-reflog-your-safety-net.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: reflog, your safety net
 category: intermediate

--- a/_posts/2009-02-10-squashing-commits-with-rebase.textile
+++ b/_posts/2009-02-10-squashing-commits-with-rebase.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: squashing commits with rebase
 category: advanced

--- a/_posts/2009-02-10-squashing-commits-with-rebase.textile
+++ b/_posts/2009-02-10-squashing-commits-with-rebase.textile
@@ -1,21 +1,21 @@
 ---
-published: false
+published: true
 layout: post
-title: squashing commits with rebase
+title: rebase 로 커밋 합치기
 category: advanced
 ---
 
-The "rebase":http://gitready.com/intermediate/2009/01/31/intro-to-rebase.html command has some awesome options available in its @--interactive@ (or @-i@) mode, and one of the most widely used is the ability to squash commits. What this does is take smaller commits and combine them into larger ones, which could be useful if you're wrapping up the day's work or if you just want to package your changes differently. We're going to go over how you can do this easily.
+"rebase":http://gitready.com/intermediate/2009/01/31/intro-to-rebase.html 명령은 @--interactive@ (혹은 @-i@) 모드일 때 굉장한 옵션들을 사용할 수 있으며, 커밋들을 합치고 싶을 때 가장 널리 사용되는 명령 중 하나이다. 이 명령이 하는 일은 작은 커밋들을 결합하여 하나의 큰 커밋으로 만드는 것이며, 만약 당신이 그날 한 일을 마무리지으려 하거나 아니면 그냥 서로 다른 변경사항들을 묶고 싶어졌을 때 유용하다. 우리는 이제 이런 일들을 어떻게 쉽게 할 수 있는지 알아볼 것이다.
 
 p=. "!http://farm4.static.flickr.com/3073/2926413646_8e4a7b7db4.jpg?v=0!":http://flickr.com/photos/7552532@N07/2926413646/
 
-*A word of caution:* Only do this on commits that haven't been pushed an external repository. If others have based work off of the commits that you're going to delete, plenty of conflicts can occur. Just don't rewrite your history if it's been shared with others. 
+*주의사항 한마디:* 오직 외부 저장소에 push 되지 않은 커밋에 대해서만 이 기능을 사용하라. 만약 다른 사람들이 당신이 삭제하려고 하는 커밋에 기반을 둔 작업을 하고 있다면, 꽤 많은 충돌이 발생할 것이다.  쉽게 말해 다른 사람과 공유하고 있는 역사를 고쳐쓰지 말라.
 
-So let's say you've just made a few small commits, and you want to make one larger commit out of them. Our repository's history currently looks like this:
+그럼 당신이 커밋을 몇번 했고, 그것들을 합쳐서 큰 커밋 하나로 만들고 싶다고 하자. 우리 저장소의 역사는 현재 다음과 같다.
 
 p=. !/images/squash1.png!
 
-The last 4 commits would be much happier if they were wrapped up together, so let's do just that through interactive rebasing:
+이 최근 4개의 커밋들은 하나로 합쳐지면 더 행복해할 것 같으니, interactive rebasing으로 그걸 해보자:
 
 <pre>
 $ git rebase -i HEAD~4
@@ -37,7 +37,7 @@ pick 30e0ccb Changed the tagline in the binary, too.
 #
 </pre>
 
-So, a few things have happened here. First of all, I told Git that I wanted to rebase using the last four commits from where the @HEAD@ is with @HEAD~4@. Git has now put me into an editor with the above text in it, and a little explanation of what can be done. You have plenty of options available to you from this screen, but right now we're just going to squash everything into one commit. So, changing the first four lines of the file to this will do the trick:
+자, 몇가지 일들이 여기서 일어났다. 우선, 나는 Git에게 @HEAD@ 부터 @HEAD~4@ 까지 지난 네 커밋을 rebase 하고 싶다고 말했다. Git는 이제 무엇을 할 수 있는지에 대한 약간의 설명을 포함한 위의 텍스트와 함께 나를 편집기로 보냈다. 화면에 여러가지 옵션들이 나타났지만, 지금 우리는 그냥 커밋들을 하나로 합치는 것만 할 것이다. 자, 위 파일의 첫 네 줄을 이렇게 바꾸면 된다:
 
 <pre>
 pick 01d1124 Adding license
@@ -46,7 +46,7 @@ squash ebfd367 Jekyll has become self-aware.
 squash 30e0ccb Changed the tagline in the binary, too.
 </pre>
 
-Basically this tells Git to combine all four commits into the the first commit in the list. Once this is done and saved, another editor pops up with the following:
+기본적으로 이것은 Git에게 나열된 네 커밋을 하나의 커밋으로 합쳐달라고 말해준다. 일단 저장하면 다음과 같이 또 에디터가 실행된다:
 
 <pre>
 # This is a combination of 4 commits.
@@ -79,6 +79,7 @@ Changed the tagline in the binary, too.
 #
 </pre>
 
+우리가 여러 커밋들을 합쳤기 때문에, Git은 당신에게 이 작업과 관련된 커밋들의 메시지로 새 커밋 메시지를 작성할 수 있게 해준다. 메시지를 원하는 대로 수정하고, 저장하고, 종료하라. 그렇게 하면 당신의 커밋들은 성공적으로 합쳐진다!
 Since we're combining so many commits, Git allows you to modify the new commit's message based on the rest of the commits involved in the process. Edit the message as you see fit, then save and quit. Once that's done, your commits have been successfully squashed!
 
 <pre>
@@ -88,10 +89,10 @@ Created commit 0fc4eea: Creating license file, and making jekyll self-aware.
 	Successfully rebased and updated refs/heads/master.
 </pre>
 
-And if we look at the history again...
+그리고 우리가 히스토리를 다시 들여다보면...
 
 p=. !/images/squash2.png!
 
-So, this has been a relatively painless so far. If you run into conflicts during the rebase, they're usually quite easy to resolve and Git leads you through as much as possible. The basics of this is fix the conflict in question, @git add@ the file, and then @git rebase --continue@ will resume the process. Of course, doing a @git rebase --abort@ will bring you back to your previous state if you want. If for some reason you've lost a commit in the rebase, you can use the "reflog":http://gitready.com/intermediate/2009/02/09/reflog-your-safety-net.html to get it back.
+이건 상대적으로 그다지 괴롭지 않다. 만약 당신이 rebase 중에 충돌 상태로 들어갔다면 그건 resolve 하기 상당히 쉽고 Git는 당신이 그걸 할 수 있도록 안내해 줄 것이다. 기본적으로 질문받은 충돌을 고치고, 그 파일을 @git add@ 하고, @git rebase --continue@ 로 계속 진행하면 된다. 물론 원한다면 @git rebase --abort@ 로 이전 상태로 돌아갈 수 있다. 어떤 이유로 인해 rebase 과정에서 커밋을 잃어버렸다면, "reflog":http://gitready.com/intermediate/2009/02/09/reflog-your-safety-net.html 를 사용해 되돌릴 수 있다.
 
-There's plenty of other uses for @git rebase -i@ that haven't been covered yet. If you have one you'd like to share, "please do so!":/submit.html "GitCasts":http://gitcasts.com also has a "fantastic video":http://gitcasts.com/posts/rebasing on this process as a whole that also covers some more complex examples of the command.
+여기서 다루지 않은 @git rebase -i@ 의 사용법이 상당히 많다. 혹시 공유하고 싶은 것이 있다면, "부디 그렇게 해달라!":/submit.html "GitCasts":http://gitcasts.com 에도, 이 과정 전반 및 더 복잡한 예제도 다루고 있는 "환상적인 영상":http://gitcasts.com/posts/rebasing 이 올라와 있다.

--- a/_posts/2009-02-10-squashing-commits-with-rebase.textile
+++ b/_posts/2009-02-10-squashing-commits-with-rebase.textile
@@ -92,6 +92,6 @@ And if we look at the history again...
 
 p=. !/images/squash2.png!
 
-So, this has been a relatively painless so far. If you run into conflicts during the rebase, they're usually quite easy to resolve and Git leads you through as much as possible. The basics of this is fix the conflict in question, @git add@ the file, and then @git rebase --continue@ will resume the process. Of course, doing a @git rebase --abort@ will bring you abck to your previous state if you want. If for some reason you've lost a commit in the rebase, you can use the "reflog":http://gitready.com/intermediate/2009/02/09/reflog-your-safety-net.html to get it back.
+So, this has been a relatively painless so far. If you run into conflicts during the rebase, they're usually quite easy to resolve and Git leads you through as much as possible. The basics of this is fix the conflict in question, @git add@ the file, and then @git rebase --continue@ will resume the process. Of course, doing a @git rebase --abort@ will bring you back to your previous state if you want. If for some reason you've lost a commit in the rebase, you can use the "reflog":http://gitready.com/intermediate/2009/02/09/reflog-your-safety-net.html to get it back.
 
 There's plenty of other uses for @git rebase -i@ that haven't been covered yet. If you have one you'd like to share, "please do so!":/submit.html "GitCasts":http://gitcasts.com also has a "fantastic video":http://gitcasts.com/posts/rebasing on this process as a whole that also covers some more complex examples of the command.

--- a/_posts/2009-02-11-pull-with-rebase.textile
+++ b/_posts/2009-02-11-pull-with-rebase.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: pull with rebase
 category: advanced

--- a/_posts/2009-02-12-easily-fetching-upstream-changes.textile
+++ b/_posts/2009-02-12-easily-fetching-upstream-changes.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: easily fetching upstream changes
 category: intermediate

--- a/_posts/2009-02-13-list-remote-branches.textile
+++ b/_posts/2009-02-13-list-remote-branches.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: list remote branches
 category: intermediate

--- a/_posts/2009-02-16-convert-git-svn-tag-branches-to-real-tags.textile
+++ b/_posts/2009-02-16-convert-git-svn-tag-branches-to-real-tags.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: convert git-svn tag branches to real tags
 category: advanced

--- a/_posts/2009-02-17-how-git-stores-your-data.textile
+++ b/_posts/2009-02-17-how-git-stores-your-data.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: how git stores your data
 category: beginner

--- a/_posts/2009-02-18-temporarily-ignoring-files.textile
+++ b/_posts/2009-02-18-temporarily-ignoring-files.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: temporarily ignoring files
 category: intermediate

--- a/_posts/2009-02-19-what-git-is-not.textile
+++ b/_posts/2009-02-19-what-git-is-not.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: what git is not
 category: beginner

--- a/_posts/2009-02-23-finding-who-committed-what.textile
+++ b/_posts/2009-02-23-finding-who-committed-what.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: finding who committed what
 category: beginner

--- a/_posts/2009-02-25-keep-either-file-in-merge-conflicts.textile
+++ b/_posts/2009-02-25-keep-either-file-in-merge-conflicts.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: keep either file in merge conflicts
 category: advanced

--- a/_posts/2009-02-27-get-a-file-from-a-specific-revision.textile
+++ b/_posts/2009-02-27-get-a-file-from-a-specific-revision.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: get a file from a specific revision
 category: intermediate

--- a/_posts/2009-03-02-where-to-find-the-git-community.textile
+++ b/_posts/2009-03-02-where-to-find-the-git-community.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: where to find the git community
 category: beginner

--- a/_posts/2009-03-04-pick-out-individual-commits.textile
+++ b/_posts/2009-03-04-pick-out-individual-commits.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: pick out individual commits
 category: intermediate

--- a/_posts/2009-03-06-ignoring-doesnt-remove-a-file.textile
+++ b/_posts/2009-03-06-ignoring-doesnt-remove-a-file.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: ignoring doesn't remove a file
 category: beginner

--- a/_posts/2009-03-09-remote-tracking-branches.textile
+++ b/_posts/2009-03-09-remote-tracking-branches.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: remote tracking branches
 category: beginner

--- a/_posts/2009-03-11-easily-manage-git-remote-branches.textile
+++ b/_posts/2009-03-11-easily-manage-git-remote-branches.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: easily manage git remote branches
 category: advanced

--- a/_posts/2009-03-13-smartly-save-stashes.textile
+++ b/_posts/2009-03-13-smartly-save-stashes.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: smartly save stashes
 category: beginner

--- a/_posts/2009-03-16-rolling-back-changes-with-revert.textile
+++ b/_posts/2009-03-16-rolling-back-changes-with-revert.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: rolling back changes with revert
 category: intermediate

--- a/_posts/2009-03-18-restoring-a-directory-from-history.textile
+++ b/_posts/2009-03-18-restoring-a-directory-from-history.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: restoring a directory from history
 category: intermediate

--- a/_posts/2009-03-20-reorder-commits-with-rebase.textile
+++ b/_posts/2009-03-20-reorder-commits-with-rebase.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: reorder commits with rebase
 category: advanced

--- a/_posts/2009-03-23-whats-inside-your-git-directory.textile
+++ b/_posts/2009-03-23-whats-inside-your-git-directory.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: what's inside your .git directory
 category: advanced

--- a/_posts/2009-04-03-find-ancestor-commits.textile
+++ b/_posts/2009-04-03-find-ancestor-commits.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: find ancestor commits
 category: intermediate

--- a/_posts/2009-04-16-find-unmerged-commits.textile
+++ b/_posts/2009-04-16-find-unmerged-commits.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: find unmerged commits
 category: intermediate

--- a/_posts/2009-07-31-tig-the-ncurses-front-end-to-git.textile
+++ b/_posts/2009-07-31-tig-the-ncurses-front-end-to-git.textile
@@ -1,4 +1,5 @@
 ---
+published: false
 layout: post
 title: tig, the ncurses front-end to Git
 category: advanced


### PR DESCRIPTION
I translated 2009-01-12-fixing-broken-commit-messages and 2009-02-10-squashing-commits-with-rebase, into Korean.

And I suppose 26ab2aa6 is not needed because it is merged already, but I don't know how to omit it.
