### PR TITLE
Fixed broken flag

### DIFF
--- a/_posts/2009-02-06-helpful-command-aliases.textile
+++ b/_posts/2009-02-06-helpful-command-aliases.textile
@@ -31,7 +31,7 @@ nothing added to commit but untracked files present (use "git add" to track)
 You can also add aliases like so, and they will get added to your @.gitconfig@ file automatically.
 
 <pre>
-$ git config –-global alias.rb rebase
+$ git config --global alias.rb rebase
 </pre>
 
 


### PR DESCRIPTION
Using "git config –-global alias.rb rebase" will result in
throw the following:
error: key does not contain a section: –-global

Instead, we should use "--global"
